### PR TITLE
feat: improve type generation

### DIFF
--- a/packages/example/src/app.tsx
+++ b/packages/example/src/app.tsx
@@ -7,16 +7,12 @@ export function App() {
         <h1 className={tw.text_xl.$}>Example App</h1>
         <span className={tw.flex_1.$}></span>
         <a
-          className={tw._("i-ri-github-line w-6 h-6").hover(tw.text_primary).$}
+          className={tw._("i-ri-github-line").w_6.h_6.hover(tw.text_primary).$}
           href="https://github.com/hi-ogawa/unocss-typescript-dsl"
         ></a>
       </header>
       <main className={tw.flex_1.flex.flex_col.items_center.px_2.$}>
-        <div
-          className={
-            tw._("w-full").max_w_xl._("border").flex.flex_col.gap_2.p_2.$
-          }
-        >
+        <div className={tw.w_full.max_w_xl.border.flex.flex_col.gap_2.p_2.$}>
           <h2 className={tw.text_lg.$}>Some header</h2>
           <div className={tw.text_red_500.$}>Some red text...</div>
           <div className={tw.text_blue_500.$}>Some blue text...</div>

--- a/packages/example/src/styles/tw-api.ts
+++ b/packages/example/src/styles/tw-api.ts
@@ -46,7 +46,8 @@ export type Theme_width =
   | `6xl`
   | `7xl`
   | `prose`
-  | `screen`;
+  | `screen`
+;
 
 export type Theme_height =
   | `auto`
@@ -62,7 +63,8 @@ export type Theme_height =
   | `6xl`
   | `7xl`
   | `prose`
-  | `screen`;
+  | `screen`
+;
 
 export type Theme_maxWidth =
   | `none`
@@ -78,7 +80,8 @@ export type Theme_maxWidth =
   | `6xl`
   | `7xl`
   | `prose`
-  | `screen`;
+  | `screen`
+;
 
 export type Theme_maxHeight =
   | `none`
@@ -94,7 +97,8 @@ export type Theme_maxHeight =
   | `6xl`
   | `7xl`
   | `prose`
-  | `screen`;
+  | `screen`
+;
 
 export type Theme_minWidth =
   | `none`
@@ -110,7 +114,8 @@ export type Theme_minWidth =
   | `6xl`
   | `7xl`
   | `prose`
-  | `screen`;
+  | `screen`
+;
 
 export type Theme_minHeight =
   | `none`
@@ -126,7 +131,8 @@ export type Theme_minHeight =
   | `6xl`
   | `7xl`
   | `prose`
-  | `screen`;
+  | `screen`
+;
 
 export type Theme_inlineSize =
   | `auto`
@@ -142,7 +148,8 @@ export type Theme_inlineSize =
   | `6xl`
   | `7xl`
   | `prose`
-  | `screen`;
+  | `screen`
+;
 
 export type Theme_blockSize =
   | `auto`
@@ -158,7 +165,8 @@ export type Theme_blockSize =
   | `6xl`
   | `7xl`
   | `prose`
-  | `screen`;
+  | `screen`
+;
 
 export type Theme_maxInlineSize =
   | `none`
@@ -174,7 +182,8 @@ export type Theme_maxInlineSize =
   | `6xl`
   | `7xl`
   | `prose`
-  | `screen`;
+  | `screen`
+;
 
 export type Theme_maxBlockSize =
   | `none`
@@ -190,7 +199,8 @@ export type Theme_maxBlockSize =
   | `6xl`
   | `7xl`
   | `prose`
-  | `screen`;
+  | `screen`
+;
 
 export type Theme_minInlineSize =
   | `none`
@@ -206,7 +216,8 @@ export type Theme_minInlineSize =
   | `6xl`
   | `7xl`
   | `prose`
-  | `screen`;
+  | `screen`
+;
 
 export type Theme_minBlockSize =
   | `none`
@@ -222,7 +233,8 @@ export type Theme_minBlockSize =
   | `6xl`
   | `7xl`
   | `prose`
-  | `screen`;
+  | `screen`
+;
 
 export type Theme_colors =
   | `inherit`
@@ -287,12 +299,14 @@ export type Theme_colors =
   | `gray_700`
   | `gray_800`
   | `gray_900`
-  | `primary`;
+  | `primary`
+;
 
 export type Theme_fontFamily =
   | `sans`
   | `serif`
-  | `mono`;
+  | `mono`
+;
 
 export type Theme_fontSize =
   | `xs`
@@ -307,21 +321,24 @@ export type Theme_fontSize =
   | `6xl`
   | `7xl`
   | `8xl`
-  | `9xl`;
+  | `9xl`
+;
 
 export type Theme_breakpoints =
   | `sm`
   | `md`
   | `lg`
   | `xl`
-  | `2xl`;
+  | `2xl`
+;
 
 export type Theme_verticalBreakpoints =
   | `sm`
   | `md`
   | `lg`
   | `xl`
-  | `2xl`;
+  | `2xl`
+;
 
 export type Theme_borderRadius =
   | `DEFAULT`
@@ -332,7 +349,8 @@ export type Theme_borderRadius =
   | `xl`
   | `2xl`
   | `3xl`
-  | `full`;
+  | `full`
+;
 
 export type Theme_lineHeight =
   | `none`
@@ -340,7 +358,8 @@ export type Theme_lineHeight =
   | `snug`
   | `normal`
   | `relaxed`
-  | `loose`;
+  | `loose`
+;
 
 export type Theme_letterSpacing =
   | `tighter`
@@ -348,7 +367,8 @@ export type Theme_letterSpacing =
   | `normal`
   | `wide`
   | `wider`
-  | `widest`;
+  | `widest`
+;
 
 export type Theme_wordSpacing =
   | `tighter`
@@ -356,7 +376,8 @@ export type Theme_wordSpacing =
   | `normal`
   | `wide`
   | `wider`
-  | `widest`;
+  | `widest`
+;
 
 export type Theme_boxShadow =
   | `DEFAULT`
@@ -366,7 +387,8 @@ export type Theme_boxShadow =
   | `lg`
   | `xl`
   | `2xl`
-  | `inner`;
+  | `inner`
+;
 
 export type Theme_textIndent =
   | `DEFAULT`
@@ -376,7 +398,8 @@ export type Theme_textIndent =
   | `lg`
   | `xl`
   | `2xl`
-  | `3xl`;
+  | `3xl`
+;
 
 export type Theme_textShadow =
   | `DEFAULT`
@@ -384,14 +407,16 @@ export type Theme_textShadow =
   | `sm`
   | `md`
   | `lg`
-  | `xl`;
+  | `xl`
+;
 
 export type Theme_textStrokeWidth =
   | `DEFAULT`
   | `none`
   | `sm`
   | `md`
-  | `lg`;
+  | `lg`
+;
 
 export type Theme_blur =
   | `0`
@@ -401,7 +426,8 @@ export type Theme_blur =
   | `lg`
   | `xl`
   | `2xl`
-  | `3xl`;
+  | `3xl`
+;
 
 export type Theme_dropShadow =
   | `DEFAULT`
@@ -410,18 +436,21 @@ export type Theme_dropShadow =
   | `lg`
   | `xl`
   | `2xl`
-  | `none`;
+  | `none`
+;
 
 export type Theme_easing =
   | `DEFAULT`
   | `linear`
   | `in`
   | `out`
-  | `in_out`;
+  | `in_out`
+;
 
 export type Theme_lineWidth =
   | `DEFAULT`
-  | `none`;
+  | `none`
+;
 
 export type Theme_spacing =
   | `DEFAULT`
@@ -437,7 +466,8 @@ export type Theme_spacing =
   | `6xl`
   | `7xl`
   | `8xl`
-  | `9xl`;
+  | `9xl`
+;
 
 export type Theme_duration =
   | `75`
@@ -449,11 +479,13 @@ export type Theme_duration =
   | `700`
   | `1000`
   | `DEFAULT`
-  | `none`;
+  | `none`
+;
 
 export type Theme_ringWidth =
   | `DEFAULT`
-  | `none`;
+  | `none`
+;
 
 export type Theme_preflightBase =
   | `__un_rotate`
@@ -505,7 +537,8 @@ export type Theme_preflightBase =
   | `__un_backdrop_invert`
   | `__un_backdrop_opacity`
   | `__un_backdrop_saturate`
-  | `__un_backdrop_sepia`;
+  | `__un_backdrop_sepia`
+;
 
 export type Theme_containers =
   | `xs`
@@ -519,7 +552,8 @@ export type Theme_containers =
   | `5xl`
   | `6xl`
   | `7xl`
-  | `prose`;
+  | `prose`
+;
 
 export type Theme_aria =
   | `busy`
@@ -531,7 +565,8 @@ export type Theme_aria =
   | `readonly`
   | `required`
   | `selected`
-  | `current_page`;
+  | `current_page`
+;
 
 export type Theme_animation_keyframes =
   | `pulse`
@@ -634,7 +669,8 @@ export type Theme_animation_keyframes =
   | `back_out_up`
   | `back_out_down`
   | `back_out_right`
-  | `back_out_left`;
+  | `back_out_left`
+;
 
 export type Theme_animation_durations =
   | `pulse`
@@ -643,7 +679,8 @@ export type Theme_animation_durations =
   | `bounce_out`
   | `flip_out_x`
   | `flip_out_y`
-  | `hinge`;
+  | `hinge`
+;
 
 export type Theme_animation_timingFns =
   | `pulse`
@@ -654,7 +691,8 @@ export type Theme_animation_timingFns =
   | `light_speed_in_left`
   | `light_speed_in_right`
   | `light_speed_out_left`
-  | `light_speed_out_right`;
+  | `light_speed_out_right`
+;
 
 export type Theme_animation_properties =
   | `bounce_alt`
@@ -679,7 +717,8 @@ export type Theme_animation_properties =
   | `zoom_out_down`
   | `zoom_out_left`
   | `zoom_out_right`
-  | `zoom_out_up`;
+  | `zoom_out_up`
+;
 
 export type Theme_animation_counts =
   | `spin`
@@ -687,7 +726,8 @@ export type Theme_animation_counts =
   | `pulse`
   | `pulse_alt`
   | `bounce`
-  | `bounce_alt`;
+  | `bounce_alt`
+;
 
 export type Theme_media =
   | `portrait`
@@ -706,10 +746,12 @@ export type Theme_media =
   | `stylus`
   | `pointer`
   | `mouse`
-  | `hd_color`;
+  | `hd_color`
+;
 
 export type Theme_supports =
-  | `grid`;
+  | `grid`
+;
 
 export type Autocomplete_num =
   | `0`
@@ -723,7 +765,8 @@ export type Autocomplete_num =
   | `10`
   | `12`
   | `24`
-  | `36`;
+  | `36`
+;
 
 export type Autocomplete_percent =
   | `0`
@@ -736,7 +779,8 @@ export type Autocomplete_percent =
   | `70`
   | `80`
   | `90`
-  | `100`;
+  | `100`
+;
 
 export type Autocomplete_directions =
   | `x`
@@ -746,7 +790,8 @@ export type Autocomplete_directions =
   | `l`
   | `r`
   | `s`
-  | `e`;
+  | `e`
+;
 
 export type RuleStatic =
   | `sr_only`
@@ -1360,7 +1405,8 @@ export type RuleStatic =
   | `content_visibility_revert_layer`
   | `content_visibility_unset`
   | `content_empty`
-  | `content_none`;
+  | `content_none`
+;
 
 export type RuleDynamic =
   | `${"max_" | "min_" | ""}${"w" | "h"}_${Autocomplete_num}`
@@ -1592,7 +1638,8 @@ export type RuleDynamic =
   | `${"position" | "pos"}_inset_${Autocomplete_directions}_${Theme_spacing}`
   | `${"position" | "pos"}_inset_${"block" | "inline"}_${Theme_spacing}`
   | `${"position" | "pos"}_inset_${"bs" | "be" | "is" | "ie"}_${Theme_spacing}`
-  | `${"position" | "pos"}_${"top" | "left" | "right" | "bottom"}_${Theme_spacing}`;
+  | `${"position" | "pos"}_${"top" | "left" | "right" | "bottom"}_${Theme_spacing}`
+;
 
 export type Variant =
   | `print`
@@ -1615,8 +1662,10 @@ export type Variant =
   | `dark`
   | `light`
   | `hover`
-  | `aria_${Theme_aria}`;
+  | `aria_${Theme_aria}`
+;
 
 export type Shortcut =
-  | `btn`;
+  | `btn`
+;
 

--- a/packages/example/src/styles/tw-api.ts
+++ b/packages/example/src/styles/tw-api.ts
@@ -1366,6 +1366,9 @@ export type RuleStatic =
   | `content_none`;
 
 export type RuleDynamic =
+  | `${"max_" | "min_" | ""}${"w" | "h"}_${Autocomplete_num}`
+  | `${"max_" | "min_" | ""}${"w" | "h"}_full`
+  | `border`
   | `placeholder_${"op" | "opacity"}`
   | `placeholder_${"op" | "opacity"}_${Autocomplete_percent}`
   | `placeholder_${Theme_colors}`

--- a/packages/example/src/styles/tw-api.ts
+++ b/packages/example/src/styles/tw-api.ts
@@ -1412,6 +1412,8 @@ export type RuleDynamic =
   | `${"max_" | "min_" | ""}${"w" | "h"}_${Autocomplete_num}`
   | `${"max_" | "min_" | ""}${"w" | "h"}_full`
   | `border`
+  | `textprefix_dynamic_rule_${Autocomplete_num}`
+  | `textprefix_static_rule`
   | `placeholder_${"op" | "opacity"}`
   | `placeholder_${"op" | "opacity"}_${Autocomplete_percent}`
   | `placeholder_${Theme_colors}`
@@ -1662,10 +1664,12 @@ export type Variant =
   | `dark`
   | `light`
   | `hover`
+  | `test_variant_${Autocomplete_directions}`
   | `aria_${Theme_aria}`
 ;
 
 export type Shortcut =
   | `btn`
+  | `shortcut`
 ;
 

--- a/packages/example/src/styles/tw-api.ts
+++ b/packages/example/src/styles/tw-api.ts
@@ -249,7 +249,6 @@ export type Theme_colors =
   | `blue_700`
   | `blue_800`
   | `blue_900`
-  | `blue_DEFAULT`
   | `red_1`
   | `red_2`
   | `red_3`
@@ -269,7 +268,6 @@ export type Theme_colors =
   | `red_700`
   | `red_800`
   | `red_900`
-  | `red_DEFAULT`
   | `gray_1`
   | `gray_2`
   | `gray_3`
@@ -289,7 +287,6 @@ export type Theme_colors =
   | `gray_700`
   | `gray_800`
   | `gray_900`
-  | `gray_DEFAULT`
   | `primary`;
 
 export type Theme_fontFamily =

--- a/packages/example/src/styles/tw-api.ts
+++ b/packages/example/src/styles/tw-api.ts
@@ -1614,7 +1614,8 @@ export type Variant =
   | `light`
   | `dark`
   | `light`
-  | `hover`;
+  | `hover`
+  | `aria_${Theme_aria}`;
 
 export type Shortcut =
   | `btn`;

--- a/packages/example/uno.config.ts
+++ b/packages/example/uno.config.ts
@@ -15,7 +15,6 @@ export default defineConfig({
     colors: {
       primary: "blue",
     },
-    // not supported
     aria: {
       "current-page": 'current="page"',
     },

--- a/packages/example/uno.config.ts
+++ b/packages/example/uno.config.ts
@@ -1,6 +1,7 @@
 import { transformerTypescriptDsl } from "@hiogawa/unocss-typescript-dsl";
 import {
   DynamicRule,
+  Preset,
   Variant,
   defineConfig,
   presetIcons,
@@ -28,6 +29,7 @@ export default defineConfig({
   },
   presets: [
     presetUno(),
+    examplePresetWithPrefix(),
     // not supported
     presetIcons({
       extraProperties: {
@@ -58,5 +60,18 @@ function dummyVariant(autocomplete: string): Variant {
   return {
     match: () => undefined,
     autocomplete,
+  };
+}
+
+function examplePresetWithPrefix(): Preset {
+  return {
+    name: examplePresetWithPrefix.name,
+    prefix: "textprefix-",
+    rules: [dummyRule("static-rule"), dummyRule("dynamic-rule-<num>")],
+    shortcuts: {
+      shortcut: "",
+    },
+    // variant cannot have "prefix"
+    variants: [dummyVariant("test-variant-<directions>")],
   };
 }

--- a/packages/example/uno.config.ts
+++ b/packages/example/uno.config.ts
@@ -1,5 +1,6 @@
 import { transformerTypescriptDsl } from "@hiogawa/unocss-typescript-dsl";
 import {
+  DynamicRule,
   defineConfig,
   presetIcons,
   presetUno,
@@ -34,6 +35,12 @@ export default defineConfig({
       },
     }),
   ],
+  rules: [
+    // workaround unsupported autocomplete by dummy rules
+    dummyRule("border"),
+    dummyRule("(max-|min-|)(w|h)-full"),
+    dummyRule("(max-|min-|)(w|h)-<num>"),
+  ],
   // requires transformerVariantGroup
   transformers: [
     transformerTypescriptDsl(),
@@ -41,3 +48,7 @@ export default defineConfig({
     transformerVariantGroup(),
   ],
 });
+
+function dummyRule(autocomplete: string): DynamicRule {
+  return [/a^/, () => "", { autocomplete }];
+}

--- a/packages/example/uno.config.ts
+++ b/packages/example/uno.config.ts
@@ -1,6 +1,7 @@
 import { transformerTypescriptDsl } from "@hiogawa/unocss-typescript-dsl";
 import {
   DynamicRule,
+  Variant,
   defineConfig,
   presetIcons,
   presetUno,
@@ -35,20 +36,28 @@ export default defineConfig({
       },
     }),
   ],
-  rules: [
-    // workaround unsupported autocomplete by dummy rules
-    dummyRule("border"),
-    dummyRule("(max-|min-|)(w|h)-full"),
-    dummyRule("(max-|min-|)(w|h)-<num>"),
-  ],
   // requires transformerVariantGroup
   transformers: [
     transformerTypescriptDsl(),
     transformerDirectives(),
     transformerVariantGroup(),
   ],
+  // dummy rules/variants to workaround unsupported autocomplete by upstream
+  rules: [
+    dummyRule("border"),
+    dummyRule("(max-|min-|)(w|h)-full"),
+    dummyRule("(max-|min-|)(w|h)-<num>"),
+  ],
+  variants: [dummyVariant("aria-$aria")],
 });
 
 function dummyRule(autocomplete: string): DynamicRule {
   return [/a^/, () => "", { autocomplete }];
+}
+
+function dummyVariant(autocomplete: string): Variant {
+  return {
+    match: () => undefined,
+    autocomplete,
+  };
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/unocss-typescript-dsl",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/lib/src/generate-api.test.ts
+++ b/packages/lib/src/generate-api.test.ts
@@ -76,7 +76,8 @@ describe("generateApi", () => {
         | \`gray_700\`
         | \`gray_800\`
         | \`gray_900\`
-        | \`primary\`;"
+        | \`primary\`
+      ;"
     `);
   });
 });

--- a/packages/lib/src/generate-api.test.ts
+++ b/packages/lib/src/generate-api.test.ts
@@ -6,7 +6,7 @@ describe("generateApi", () => {
   it("basic", async () => {
     const output = await generateApi({
       optimize: {
-        filterColors: ["@(gray|blue)-*"],
+        filterColors: ["@(gray|blue)-*", "red*"],
       },
     });
     const match = output.match(/export type Theme_colors =(.*?);/ms);
@@ -37,7 +37,26 @@ describe("generateApi", () => {
         | \`blue_700\`
         | \`blue_800\`
         | \`blue_900\`
-        | \`blue_DEFAULT\`
+        | \`red_1\`
+        | \`red_2\`
+        | \`red_3\`
+        | \`red_4\`
+        | \`red_5\`
+        | \`red_6\`
+        | \`red_7\`
+        | \`red_8\`
+        | \`red_9\`
+        | \`red_50\`
+        | \`red_100\`
+        | \`red_200\`
+        | \`red_300\`
+        | \`red_400\`
+        | \`red_500\`
+        | \`red_600\`
+        | \`red_700\`
+        | \`red_800\`
+        | \`red_900\`
+        | \`red\`
         | \`gray_1\`
         | \`gray_2\`
         | \`gray_3\`
@@ -57,7 +76,6 @@ describe("generateApi", () => {
         | \`gray_700\`
         | \`gray_800\`
         | \`gray_900\`
-        | \`gray_DEFAULT\`
         | \`primary\`;"
     `);
   });

--- a/packages/lib/src/generate-api.ts
+++ b/packages/lib/src/generate-api.ts
@@ -98,7 +98,9 @@ ${API_DEFINITION}
   //
   // static rule (e.g. flex, cursor-pointer)
   //
-  const rulesStatic = Object.keys(uno.config.rulesStaticMap);
+  const rulesStatic = Object.entries(uno.config.rulesStaticMap).map(
+    ([key, value]) => (value?.[2]?.prefix ?? "") + key
+  );
   const rulesStaticApi = rulesStatic.map((rule) => rule.replaceAll("-", "_"));
   result += toStringUnionType("RuleStatic", rulesStaticApi);
 
@@ -110,7 +112,8 @@ ${API_DEFINITION}
     const meta = rule[3];
     const autocompletes = [meta?.autocomplete ?? []].flat();
     for (const autocomplete of autocompletes) {
-      rulesDynamic.push(resolveAutocomplete(autocomplete));
+      const resolved = resolveAutocomplete(autocomplete);
+      rulesDynamic.push((meta?.prefix ?? "") + resolved);
     }
   }
   const rulesDynamicApi = rulesDynamic.map((rule) => rule.replaceAll("-", "_"));
@@ -122,6 +125,7 @@ ${API_DEFINITION}
   const variants: string[] = [];
   for (const variant of uno.config.variants) {
     // TODO: some variant doesn't have autocomplete? (e.g. aria-xxx)
+    // TODO: variant cannot have "prefix"
     let autocompletes = [variant?.autocomplete ?? []].flat();
     for (let autocomplete of autocompletes) {
       if (typeof autocomplete !== "string") {

--- a/packages/lib/src/generate-api.ts
+++ b/packages/lib/src/generate-api.ts
@@ -178,7 +178,8 @@ function toStringUnionType(name: string, values: string[]): string {
   // "never" to gracefully handle empty options
   return `\
 export type ${name} =
-${values.map((s) => `  | \`${s}\``).join("\n") || "  | never"};
+${values.map((s) => `  | \`${s}\``).join("\n") || "  | never"}
+;
 
 `;
 }

--- a/packages/lib/src/generate-api.ts
+++ b/packages/lib/src/generate-api.ts
@@ -51,9 +51,14 @@ ${API_DEFINITION}
       const values: string[] = [];
       for (const [innerName, inner] of Object.entries(outer as any)) {
         if (inner && typeof inner === "object" && !Array.isArray(inner)) {
-          let innerValues = Object.keys(inner).map(
-            (key) => `${innerName}-${key}`
-          );
+          let innerValues: string[] = [];
+          for (const innerName2 of Object.keys(inner)) {
+            if (IGNORED_THEME_KEYS.includes(innerName2)) {
+              innerValues.push(innerName);
+            } else {
+              innerValues.push(`${innerName}-${innerName2}`);
+            }
+          }
           if (filters.length > 0) {
             innerValues = innerValues.filter((value) =>
               filters.some((filter) => filter.match(value))
@@ -177,6 +182,9 @@ ${values.map((s) => `  | \`${s}\``).join("\n") || "  | never"};
 
 `;
 }
+
+// https://github.com/unocss/unocss/blob/33290b66103c0c35e868212fd6c12947faa0a027/packages/autocomplete/src/parse.ts#L9
+const IGNORED_THEME_KEYS = ["DEFAULT"];
 
 //
 // based on https://github.com/unocss/unocss/blob/2e74b31625bbe3b9c8351570749aa2d3f799d919/packages/autocomplete/src/parse.ts#L31

--- a/packages/lib/src/generate-api.ts
+++ b/packages/lib/src/generate-api.ts
@@ -121,7 +121,7 @@ ${API_DEFINITION}
   //
   const variants: string[] = [];
   for (const variant of uno.config.variants) {
-    // TODO: some variant doesn't have autocomplete? (e.g. hover, aria)
+    // TODO: some variant doesn't have autocomplete? (e.g. aria-xxx)
     let autocompletes = [variant?.autocomplete ?? []].flat();
     for (let autocomplete of autocompletes) {
       if (typeof autocomplete !== "string") {

--- a/packages/lib/tsup.config.ts
+++ b/packages/lib/tsup.config.ts
@@ -5,4 +5,5 @@ export default defineConfig({
   format: ["esm", "cjs"],
   dts: true,
   splitting: false,
+  sourcemap: "inline",
 });


### PR DESCRIPTION
- partially addresses https://github.com/hi-ogawa/unocss-typescript-dsl/issues/4

## summary

- [x] `dummyRule/dummyVariant` allows users to workaround unsupported autcomplete quite easily
- [x] handle special `DEFAULT` token
  - cf. https://github.com/unocss/unocss/blob/33290b66103c0c35e868212fd6c12947faa0a027/packages/autocomplete/src/parse.ts#L9
- [x] handle `prefix` option
  - variant doesn't have prefix config