### PR TITLE
feat: support string coercion

### DIFF
--- a/packages/lib/src/runtime.test.ts
+++ b/packages/lib/src/runtime.test.ts
@@ -53,4 +53,27 @@ describe("runtime", () => {
       '"bg-white aria-selected:(bg-gray-100 text-blue-600)"'
     );
   });
+
+  describe("coercion", () => {
+    it("String", () => {
+      const tw = createApi() as any;
+      expect(String(tw.flex.justify_center.items_center)).toMatchInlineSnapshot(
+        '"flex justify-center items-center"'
+      );
+    });
+
+    it("interpolation", () => {
+      const tw = createApi() as any;
+      expect(`${tw.flex.justify_center.items_center}`).toMatchInlineSnapshot(
+        '"flex justify-center items-center"'
+      );
+    });
+
+    it("toString", () => {
+      const tw = createApi() as any;
+      expect(
+        tw.flex.justify_center.items_center.toString()
+      ).toMatchInlineSnapshot('"flex justify-center items-center"');
+    });
+  });
 });

--- a/packages/lib/src/runtime.ts
+++ b/packages/lib/src/runtime.ts
@@ -62,7 +62,7 @@ function createApiIntenal() {
 
   const proxy: unknown = new Proxy(
     {
-      // support "reasonable" conversion since otherwise it would be too easy to throw when mis-typing
+      // support "reasonable" conversion since otherwise it would be too easy to throw (and take down whole vite dev server) when mis-typing
       // especially because typescript doesn't catch implic coercion https://github.com/microsoft/TypeScript/issues/30239
 
       // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive


### PR DESCRIPTION
otherwise it would be too unforgiving about typo and it can lead to crashing whole vite dev server...

```txt
4:45:34 PM [vite] (local:unocssDepHmrPlugin) reloading uno.config.ts ...
/home/hiroshi/code/personal/unocss-preset-antd/packages/lib/dist/index.js:1120
      tinyassert(typeof prop === "string");
      ^

TinyAssertionError
    at Object.get (/home/hiroshi/code/personal/unocss-preset-antd/packages/lib/dist/index.js:1120:7)
```