### PR TITLE
refactor!: separate runtime entrypoint

### DIFF
--- a/packages/example/src/styles/tw.ts
+++ b/packages/example/src/styles/tw.ts
@@ -1,5 +1,5 @@
-import { createApi } from "@hiogawa/unocss-typescript-dsl/dist/runtime";
+import { createRuntime } from "@hiogawa/unocss-typescript-dsl/dist/runtime";
 import type { Api } from "./tw-api";
 
-// `createApi` (aka runtime) itself is so tiny, so it doesn't matter whether we eliminate it from bundle
-export const tw = createApi() as Api;
+// runtime is so tiny and with no dependency, so it doesn't matter whether we eliminate it from bundle
+export const tw = createRuntime() as Api;

--- a/packages/example/src/styles/tw.ts
+++ b/packages/example/src/styles/tw.ts
@@ -1,4 +1,4 @@
-import { createApi } from "@hiogawa/unocss-typescript-dsl";
+import { createApi } from "@hiogawa/unocss-typescript-dsl/dist/runtime";
 import type { Api } from "./tw-api";
 
 // `createApi` (aka runtime) itself is so tiny, so it doesn't matter whether we eliminate it from bundle

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -10,6 +10,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts"
+    },
+    "./dist/runtime": {
+      "import": "./dist/runtime.js",
+      "require": "./dist/runtime.cjs",
+      "types": "./dist/runtime.d.ts"
     }
   },
   "bin": "./bin/cli.mjs",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/unocss-typescript-dsl",
-  "version": "1.1.0",
+  "version": "2.0.0-pre.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/lib/src/common.ts
+++ b/packages/lib/src/common.ts
@@ -1,0 +1,36 @@
+// TODO: configurable
+export const API_NAME = "tw";
+export const PROP_CUSTOM_RULE = "_";
+export const PROP_CUSTOM_VARIANT = "_v";
+export const PROP_TO_STRING = "$";
+
+//
+// Api definition
+//
+
+export const API_DEFINITION = `\
+type Property = RuleStatic | RuleDynamic | Shortcut;
+type Method = Variant;
+
+type ApiProperty = {
+  [key in Property]: Api;
+};
+
+type ApiMethod = {
+  [key in Method]: (inner: Api) => Api;
+};
+
+// escape hatch to allow arbitrary values which are not supported by auto-generation
+type ApiCustom = {
+  _: (raw: string) => Api; // for rule
+  _v: (raw: string, inner: Api) => Api; // for variant
+};
+
+// force special property to dump the resulting class string,
+// which allows transform to be implemented trivially via regex
+type ApiToString = {
+  $: string;
+};
+
+export type Api = ApiProperty & ApiMethod & ApiCustom & ApiToString;
+`;

--- a/packages/lib/src/generate-api.ts
+++ b/packages/lib/src/generate-api.ts
@@ -2,8 +2,8 @@ import { tinyassert } from "@hiogawa/utils";
 import { loadConfig } from "@unocss/config";
 import { createGenerator } from "@unocss/core";
 import { Minimatch } from "minimatch";
+import { API_DEFINITION } from "./common";
 import { mapRegex } from "./regex-utils";
-import { API_DEFINITION } from "./runtime";
 
 export interface GenerateApiOptions {
   cwd?: string;

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,3 +1,2 @@
 export { transformerTypescriptDsl } from "./transform";
-export { createApi } from "./runtime";
 export * from "./workaround";

--- a/packages/lib/src/runtime.test.ts
+++ b/packages/lib/src/runtime.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { createApi } from "./runtime";
+import { createRuntime } from "./runtime";
 
 describe("runtime", () => {
   it("basic", () => {
-    const tw = createApi() as any;
+    const tw = createRuntime() as any;
 
     expect(tw.flex.justify_center.items_center.$).toMatchInlineSnapshot(
       '"flex justify-center items-center"'
@@ -15,7 +15,7 @@ describe("runtime", () => {
   });
 
   it("variant", () => {
-    const tw = createApi() as any;
+    const tw = createRuntime() as any;
     expect(
       tw.animate_spin.sm(tw.hidden).md(tw.inline.text_red_500).$
     ).toMatchInlineSnapshot(
@@ -32,21 +32,21 @@ describe("runtime", () => {
   });
 
   it("user-defined", () => {
-    const tw = createApi() as any;
+    const tw = createRuntime() as any;
     expect(tw.text_primary.bg_white.$).toMatchInlineSnapshot(
       '"text-primary bg-white"'
     );
   });
 
   it("custom rule", () => {
-    const tw = createApi() as any;
+    const tw = createRuntime() as any;
     expect(
       tw.text_gray_500._("bg-[#123]")._("border-[#456]").$
     ).toMatchInlineSnapshot('"text-gray-500 bg-[#123] border-[#456]"');
   });
 
   it("custom variant", () => {
-    const tw = createApi() as any;
+    const tw = createRuntime() as any;
     expect(
       tw.bg_white._v("aria-selected", tw.bg_gray_100.text_blue_600).$
     ).toMatchInlineSnapshot(
@@ -56,21 +56,21 @@ describe("runtime", () => {
 
   describe("coercion", () => {
     it("String", () => {
-      const tw = createApi() as any;
+      const tw = createRuntime() as any;
       expect(String(tw.flex.justify_center.items_center)).toMatchInlineSnapshot(
         '"flex justify-center items-center"'
       );
     });
 
     it("interpolation", () => {
-      const tw = createApi() as any;
+      const tw = createRuntime() as any;
       expect(`${tw.flex.justify_center.items_center}`).toMatchInlineSnapshot(
         '"flex justify-center items-center"'
       );
     });
 
     it("toString", () => {
-      const tw = createApi() as any;
+      const tw = createRuntime() as any;
       expect(
         tw.flex.justify_center.items_center.toString()
       ).toMatchInlineSnapshot('"flex justify-center items-center"');

--- a/packages/lib/src/runtime.ts
+++ b/packages/lib/src/runtime.ts
@@ -11,13 +11,13 @@ import {
 
 // based on https://github.com/Mokshit06/typewind/blob/1526e6c086ca6607f0060ce8ede66474585efde4/packages/typewind/src/evaluate.ts
 // TODO: rename to createRuntime?
-export function createApi() {
+export function createRuntime() {
   return new Proxy(
     {},
     {
       get(_target, prop: string) {
         // instantiate clean instance on first property access
-        const apiInternal = createApiIntenal();
+        const apiInternal = createRuntimeInternal();
         // @ts-expect-error requires any
         return apiInternal[prop];
       },
@@ -25,7 +25,7 @@ export function createApi() {
   );
 }
 
-function createApiIntenal() {
+function createRuntimeInternal() {
   // accumulate css classes by intercepting a property access
   let result: string[] = [];
   const getResult = () => result.join(" ");

--- a/packages/lib/src/runtime.ts
+++ b/packages/lib/src/runtime.ts
@@ -1,41 +1,9 @@
 import { tinyassert } from "@hiogawa/utils";
-
-// TODO: configurable
-export const API_NAME = "tw";
-export const PROP_CUSTOM_RULE = "_";
-export const PROP_CUSTOM_VARIANT = "_v";
-export const PROP_TO_STRING = "$";
-
-//
-// Api definition (i.e. typescript dsl)
-//
-
-export const API_DEFINITION = `\
-type Property = RuleStatic | RuleDynamic | Shortcut;
-type Method = Variant;
-
-type ApiProperty = {
-  [key in Property]: Api;
-};
-
-type ApiMethod = {
-  [key in Method]: (inner: Api) => Api;
-};
-
-// escape hatch to allow arbitrary values which are not supported by auto-generation
-type ApiCustom = {
-  _: (raw: string) => Api; // for rule
-  _v: (raw: string, inner: Api) => Api; // for variant
-};
-
-// force special property to dump the resulting class string,
-// which allows transform to be implemented trivially via regex
-type ApiToString = {
-  $: string;
-};
-
-export type Api = ApiProperty & ApiMethod & ApiCustom & ApiToString;
-`;
+import {
+  PROP_CUSTOM_RULE,
+  PROP_CUSTOM_VARIANT,
+  PROP_TO_STRING,
+} from "./common";
 
 //
 // Api runtime implementation

--- a/packages/lib/src/runtime.ts
+++ b/packages/lib/src/runtime.ts
@@ -42,6 +42,7 @@ export type Api = ApiProperty & ApiMethod & ApiCustom & ApiToString;
 //
 
 // based on https://github.com/Mokshit06/typewind/blob/1526e6c086ca6607f0060ce8ede66474585efde4/packages/typewind/src/evaluate.ts
+// TODO: rename to createRuntime?
 export function createApi() {
   return new Proxy(
     {},

--- a/packages/lib/src/transform.test.ts
+++ b/packages/lib/src/transform.test.ts
@@ -17,17 +17,13 @@ describe("transform", () => {
 
   it("global", () => {
     const input = `\
-      const tw = createApi() as Api;
-
       expect(tw.flex.justify_center.items_center.$).toMatchInlineSnapshot(xxx);
 
       expect(tw.flex.flex_col.justify_end.$).toMatchInlineSnapshot(xxx);
 `;
     const output = transform(input);
     expect(output).toMatchInlineSnapshot(`
-      "      const tw = createApi() as Api;
-
-            expect(\\"flex justify-center items-center\\").toMatchInlineSnapshot(xxx);
+      "      expect(\\"flex justify-center items-center\\").toMatchInlineSnapshot(xxx);
 
             expect(\\"flex flex-col justify-end\\").toMatchInlineSnapshot(xxx);
       "
@@ -68,8 +64,6 @@ describe("transform", () => {
 describe("debug-regex", () => {
   it("global", () => {
     const input = `\
-      const tw = createApi() as Api;
-
       expect(tw.flex.justify_center.items_center.$).toMatchInlineSnapshot(xxx);
 
       expect(tw.flex.flex_col.justify_end.$).toMatchInlineSnapshot(xxx);

--- a/packages/lib/src/transform.ts
+++ b/packages/lib/src/transform.ts
@@ -1,8 +1,9 @@
 import vm from "node:vm";
 import type { SourceCodeTransformer } from "@unocss/core";
 import type MagicString from "magic-string";
+import { API_NAME, PROP_TO_STRING } from "./common";
 import { escapeRegex, mapRegex } from "./regex-utils";
-import { API_NAME, PROP_TO_STRING, createApi } from "./runtime";
+import { createApi } from "./runtime";
 
 export function transformerTypescriptDsl(): SourceCodeTransformer {
   return {

--- a/packages/lib/src/transform.ts
+++ b/packages/lib/src/transform.ts
@@ -3,7 +3,7 @@ import type { SourceCodeTransformer } from "@unocss/core";
 import type MagicString from "magic-string";
 import { API_NAME, PROP_TO_STRING } from "./common";
 import { escapeRegex, mapRegex } from "./regex-utils";
-import { createApi } from "./runtime";
+import { createRuntime } from "./runtime";
 
 export function transformerTypescriptDsl(): SourceCodeTransformer {
   return {
@@ -39,7 +39,7 @@ export function transform(input: string): string {
 // evaluate code
 //   "tw.flex.justify_center.items_center.$" => "flex justify-center items-center"
 function evaluate(apiName: string, expression: string): string {
-  const api = createApi();
+  const api = createRuntime();
   const context = { __result: "", __api: api };
   const code = `\
 const ${apiName} = __api;

--- a/packages/lib/tsup.config.ts
+++ b/packages/lib/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/cli.ts"],
+  entry: ["src/index.ts", "src/runtime.ts", "src/cli.ts"],
   format: ["esm", "cjs"],
   dts: true,
   splitting: false,


### PR DESCRIPTION
default `index.ts` entrypoint has heavy nodejs specific dependencies (e.g. `vm`, `local-pkg`), so it makes sense to separate it from `runtime.ts` since runtime itself is zero dependencies.