### PR TITLE
feat: export runtime directly + provide types via `.d.ts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # unocss typescript DSL
 
+TODO: rename package to `@hiogawa/unocss-ts`?
+TODO: stackblitz demo
+
 Adapting the idea of [typewind](https://github.com/Mokshit06/typewind) to [unocss](https://github.com/unocss/unocss).
 
 Notable differences are:

--- a/packages/lib/src/cli-v2.ts
+++ b/packages/lib/src/cli-v2.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { TinyCli, arg, tinyCliMain } from "@hiogawa/tiny-cli";
 import { version as packageVersion } from "../package.json";
-import { transform } from "./transform";
+import { transformString } from "./transform";
 
 const cli = new TinyCli({
   program: "unocss-typescript-dsl-pre",
@@ -30,7 +30,7 @@ cli.defineCommand(
 
 async function transformFile(file: string): Promise<boolean> {
   const input = await fs.promises.readFile(file, "utf-8");
-  const output = transform(input);
+  const output = transformString(input);
   if (input === output) {
     return false;
   }

--- a/packages/lib/src/transform.test.ts
+++ b/packages/lib/src/transform.test.ts
@@ -1,61 +1,109 @@
+import MagicString from "magic-string";
 import { describe, expect, it } from "vitest";
-import { createRegex, transform } from "./transform";
+import { createRegex, transformMagicString } from "./transform";
 
-// example inputs are copied from src/runtime.test.ts
+function transform(s: string) {
+  return transformMagicString(new MagicString(s)).toString();
+}
 
 describe("transform", () => {
   it("basic", () => {
     const input = `\
-      expect(tw.flex.justify_center.items_center.$).toMatchInlineSnapshot(xxx);
+       ___(tw.flex.justify_center.items_center.$).___;
 `;
     const output = transform(input);
     expect(output).toMatchInlineSnapshot(`
-      "      expect("flex justify-center items-center").toMatchInlineSnapshot(xxx);
+      "       ___("flex justify-center items-center").___;
       "
+    `);
+  });
+
+  it("example", () => {
+    const input = `
+      <div className={tw.flex.flex_col.gap_4.$}>
+        <header className={tw.flex.items_center.p_2.px_4.shadow_md.$}>
+          <h1 className={tw.text_xl.$}>Example App</h1>
+          <span className={tw.flex_1.$}></span>
+          <a
+            className={tw.i_ri_github_line.w_6.h_6.hover(tw.text_primary).$}
+            href="https://github.com/hi-ogawa/unocss-typescript-dsl"
+          ></a>
+        </header>
+        <main className={tw.flex_1.flex.flex_col.items_center.px_2.$}>
+          <div className={tw.w_full.max_w_xl.border.flex.flex_col.gap_2.p_2.$}>
+            <h2 className={tw.text_lg.$}>Some header</h2>
+            <div className={tw.text_red_500.$}>Some red text...</div>
+            <div className={tw.text_blue_500.$}>Some blue text...</div>
+            <button className={tw.btn.p_1.$}>Some button</button>
+          </div>
+        </main>
+      </div>
+    `;
+    expect(transform(input)).toMatchInlineSnapshot(`
+      "
+            <div className={"flex flex-col gap-4"}>
+              <header className={"flex items-center p-2 px-4 shadow-md"}>
+                <h1 className={"text-xl"}>Example App</h1>
+                <span className={"flex-1"}></span>
+                <a
+                  className={"i-ri-github-line w-6 h-6 hover:(text-primary)"}
+                  href="https://github.com/hi-ogawa/unocss-typescript-dsl"
+                ></a>
+              </header>
+              <main className={"flex-1 flex flex-col items-center px-2"}>
+                <div className={"w-full max-w-xl border flex flex-col gap-2 p-2"}>
+                  <h2 className={"text-lg"}>Some header</h2>
+                  <div className={"text-red-500"}>Some red text...</div>
+                  <div className={"text-blue-500"}>Some blue text...</div>
+                  <button className={"btn p-1"}>Some button</button>
+                </div>
+              </main>
+            </div>
+          "
     `);
   });
 
   it("global", () => {
     const input = `\
-      expect(tw.flex.justify_center.items_center.$).toMatchInlineSnapshot(xxx);
+       ___(tw.flex.justify_center.items_center.$).___;
 
-      expect(tw.flex.flex_col.justify_end.$).toMatchInlineSnapshot(xxx);
+       ___(tw.flex.flex_col.justify_end.$).___;
 `;
     const output = transform(input);
     expect(output).toMatchInlineSnapshot(`
-      "      expect("flex justify-center items-center").toMatchInlineSnapshot(xxx);
+      "       ___("flex justify-center items-center").___;
 
-            expect("flex flex-col justify-end").toMatchInlineSnapshot(xxx);
+             ___("flex flex-col justify-end").___;
       "
     `);
   });
 
   it("multiline", () => {
     const input = `\
-      expect(tw.flex.
+       ___(tw.flex.
         justify_center
-        .items_center.$).toMatchInlineSnapshot(xxx);
+        .items_center.$).___;
 `;
     const output = transform(input);
     expect(output).toMatchInlineSnapshot(`
-      "      expect("flex justify-center items-center").toMatchInlineSnapshot(xxx);
+      "       ___("flex justify-center items-center").___;
       "
     `);
   });
 
   it("nested", () => {
     const input = `\
-      expect(
+       ___(
         tw.animate_spin
           .sm(tw.hidden)
           .md(tw.inline.text_red_500.disabled(tw.text_gray_500)).$
-      ).toMatchInlineSnapshot(xxx);
+      ).___;
 `;
     const output = transform(input);
     expect(output).toMatchInlineSnapshot(`
-      "      expect(
+      "       ___(
               "animate-spin sm:(hidden) md:(inline text-red-500 disabled:(text-gray-500))"
-            ).toMatchInlineSnapshot(xxx);
+            ).___;
       "
     `);
   });
@@ -64,9 +112,9 @@ describe("transform", () => {
 describe("debug-regex", () => {
   it("global", () => {
     const input = `\
-      expect(tw.flex.justify_center.items_center.$).toMatchInlineSnapshot(xxx);
+       ___(tw.flex.justify_center.items_center.$).___;
 
-      expect(tw.flex.flex_col.justify_end.$).toMatchInlineSnapshot(xxx);
+       ___(tw.flex.flex_col.justify_end.$).___;
 `;
     const regex = createRegex("tw", "$");
     expect([...input.matchAll(regex)]).toMatchInlineSnapshot(`
@@ -83,9 +131,9 @@ describe("debug-regex", () => {
 
   it("multiline", () => {
     const input = `\
-      expect(tw.flex.
+       ___(tw.flex.
         justify_center
-        .items_center.$).toMatchInlineSnapshot(xxx);
+        .items_center.$).___;
 `;
     const regex = createRegex("tw", "$");
     expect([...input.matchAll(regex)]).toMatchInlineSnapshot(`
@@ -102,11 +150,11 @@ describe("debug-regex", () => {
   it("nested", () => {
     const regex = createRegex("tw", "$");
     const input = `\
-      expect(
+       ___(
         tw.animate_spin
           .sm(tw.hidden)
           .md(tw.inline.text_red_500.disabled(tw.text_gray_500)).$
-      ).toMatchInlineSnapshot(xxx);
+      ).___;
 `;
     expect([...input.matchAll(regex)]).toMatchInlineSnapshot(`
       [

--- a/packages/lib/src/transform.ts
+++ b/packages/lib/src/transform.ts
@@ -1,4 +1,4 @@
-import vm from "node:vm";
+import vm from "node:vm"; // TODO: dynamic `node:vm` import or just use eval
 import type { SourceCodeTransformer } from "@unocss/core";
 import type MagicString from "magic-string";
 import { API_NAME, PROP_TO_STRING } from "./common";
@@ -16,6 +16,7 @@ export function transformerTypescriptDsl(): SourceCodeTransformer {
 }
 
 export function transformMagicString(code: MagicString) {
+  // TODO: improve magic-string update
   const output = transform(code.toString());
   code.overwrite(0, code.length(), output);
 }
@@ -50,6 +51,7 @@ __result = ${expression};
   return `"${context.__result}"`;
 }
 
+// TODO: strip literal before regex?
 // match example
 //   tw.xxx.yyy(tw.abc).zzz.$
 //   ~~~                   ~~

--- a/packages/lib/src/transform.ts
+++ b/packages/lib/src/transform.ts
@@ -1,4 +1,3 @@
-import vm from "node:vm"; // TODO: dynamic `node:vm` import or just use eval
 import type { SourceCodeTransformer } from "@unocss/core";
 import type MagicString from "magic-string";
 import { API_NAME, PROP_TO_STRING } from "./common";
@@ -41,14 +40,8 @@ export function transform(input: string): string {
 //   "tw.flex.justify_center.items_center.$" => "flex justify-center items-center"
 function evaluate(apiName: string, expression: string): string {
   const api = createRuntime();
-  const context = { __result: "", __api: api };
-  const code = `\
-const ${apiName} = __api;
-__result = ${expression};
-`;
-  vm.createContext(context);
-  vm.runInContext(code, context);
-  return `"${context.__result}"`;
+  const result = (0, eval)(`(${apiName}) => ${expression}`)(api);
+  return `"${result}"`;
 }
 
 // TODO: strip literal before regex?


### PR DESCRIPTION
## todo

- [ ] export runtime from a package
- [ ] provide types by generating `.d.ts`
- [ ] improve transform
  - js token, strip literal before regex?
  - rollup parser?

## todo (chore)

- [ ] rename to `unocss-ts`
- [ ] stackblitz demo
- [x] replace `vm` with `eval`
- [x] improve magic-string https://github.com/hi-ogawa/unocss-typescript-dsl/pull/31
- [ ] fix `dependencies` and `peerDependencies`
- [ ] re-bump cli